### PR TITLE
Add a 'respondsToSelector:' check for 'collectionView:heightForHeaderInLayout:'

### DIFF
--- a/CHTCollectionViewWaterfallLayout.m
+++ b/CHTCollectionViewWaterfallLayout.m
@@ -167,9 +167,11 @@ const int unionSize = 20;
 		}
 	}
 
-    BOOL hasHeader = [self.delegate collectionView:self.collectionView heightForHeaderInLayout:self] > 0;
-    if (hasHeader && _headerAttributes && CGRectIntersectsRect(rect, [_headerAttributes frame])) {
-        [attrs addObject:_headerAttributes];
+    if ([self.delegate respondsToSelector:@selector(collectionView:heightForHeaderInLayout:)]) {
+        BOOL hasHeader = [self.delegate collectionView:self.collectionView heightForHeaderInLayout:self] > 0;
+        if (hasHeader && _headerAttributes && CGRectIntersectsRect(rect, [_headerAttributes frame])) {
+            [attrs addObject:_headerAttributes];
+        }
     }
 
 	return [attrs copy];


### PR DESCRIPTION
Since _'collectionView:heightForHeaderInLayout:'_ is an optional delegate method, a _'respondsToSelector:'_ check should be added within _'layoutAttributesForElementsInRect:'_. Without the check you will receive an unrecognized selector crash if the method is not present.
