### PR TITLE
Call [self commonInit] also in initWithCoder:

### DIFF
--- a/CHTCollectionViewWaterfallLayout.m
+++ b/CHTCollectionViewWaterfallLayout.m
@@ -92,7 +92,7 @@ const NSInteger unionSize = 20;
 }
 
 - (id)initWithCoder:(NSCoder *)aDecoder {
-    self = [super init];
+    self = [super initWithCoder:aDecoder];
     if (self) {
         [self commonInit];
     }


### PR DESCRIPTION
When using Nibs / storyboards for initializing the layout, initWithCoder
is the designated initializer.
