### PR TITLE
Order in which items will be rendered 

### DIFF
--- a/CHTCollectionViewWaterfallLayout.h
+++ b/CHTCollectionViewWaterfallLayout.h
@@ -8,6 +8,15 @@
 #import <UIKit/UIKit.h>
 
 /**
+ *  Enumerated structure to define direction in which items can be rendered.
+ */
+typedef NS_ENUM(NSUInteger, ItemRenderDirection) {
+    kItemRenderDirectionShortestFirst,
+    kItemRenderDirectionLTR,
+    kItemRenderDirectionRTL
+};
+
+/**
  *  Constants that specify the types of supplementary views that can be presented using a waterfall layout.
  */
 
@@ -197,9 +206,22 @@ extern NSString *const CHTCollectionElementKindSectionFooter;
 @property (nonatomic, assign) UIEdgeInsets sectionInset;
 
 /**
+ *  @brief The direction in which items will be rendered in subsequent rows.
+ *  @discussion
+ *    The direction in which each item is rendered. This could be left to right (kItemRenderDirectionLTR), right to left (kItemRenderDirectionRTL), or shortest column fills first (kItemRenderDirectionShortestFirst).
+ *
+ *    Default: kItemRenderDirectionShortestFirst
+ */
+@property (nonatomic, assign) ItemRenderDirection itemRenderDirection;
+
+/**
  *  @brief The calculated width of an item in the specified section.
  *  @discussion
  *    The width of an item is calculated based on number of columns, the collection view width, and the horizontal insets for that section.
  */
 - (CGFloat)itemWidthInSectionAtIndex:(NSInteger)section;
+
 @end
+
+
+

--- a/CHTCollectionViewWaterfallLayout.m
+++ b/CHTCollectionViewWaterfallLayout.m
@@ -75,6 +75,13 @@ const NSInteger unionSize = 20;
   }
 }
 
+- (void)setItemRenderDirection:(ItemRenderDirection)itemRenderDirection {
+    if (_itemRenderDirection != itemRenderDirection) {
+        _itemRenderDirection = itemRenderDirection;
+        [self invalidateLayout];
+    }
+}
+
 - (CGFloat)itemWidthInSectionAtIndex:(NSInteger)section {
   UIEdgeInsets sectionInset;
   if ([self.delegate respondsToSelector:@selector(collectionView:layout:insetForSectionAtIndex:)]) {
@@ -141,6 +148,7 @@ const NSInteger unionSize = 20;
   _headerHeight = 0;
   _footerHeight = 0;
   _sectionInset = UIEdgeInsetsZero;
+  _itemRenderDirection = kItemRenderDirectionShortestFirst;
 }
 
 - (id)init {
@@ -242,7 +250,7 @@ const NSInteger unionSize = 20;
     // Item will be put into shortest column.
     for (idx = 0; idx < itemCount; idx++) {
       NSIndexPath *indexPath = [NSIndexPath indexPathForItem:idx inSection:section];
-      NSUInteger columnIndex = [self shortestColumnIndex];
+        NSUInteger columnIndex = [self nextColumnIndexFor:idx];
       CGFloat xOffset = sectionInset.left + (itemWidth + self.minimumColumnSpacing) * columnIndex;
       CGFloat yOffset = [self.columnHeights[columnIndex] floatValue];
       CGSize itemSize = [self.delegate collectionView:self.collectionView layout:self sizeForItemAtIndexPath:indexPath];
@@ -407,6 +415,22 @@ const NSInteger unionSize = 20;
   }];
 
   return index;
+}
+
+/**
+ *  Find the index for the next column.
+ *
+ *  @return index for the next column
+ */
+- (NSUInteger)nextColumnIndexFor:(int)idx {
+    NSUInteger index = 0;
+    switch (_itemRenderDirection) {
+        case kItemRenderDirectionShortestFirst: index = [self shortestColumnIndex];   break;
+        case kItemRenderDirectionLTR: index = (idx % _columnCount);   break;
+        case kItemRenderDirectionRTL: index = (_columnCount - 1) - (idx % _columnCount);   break;
+        default: index = [self shortestColumnIndex];    break;
+    }
+    return index;
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Read the demo codes and `CHTCollectionViewWaterfallLayout.h` header file for mor
 
 #### Step 1
 Below lists the properties for you to customize the layout. Although they have default values, I strongly recommand you to set up at least the `columnCount` property to suit your needs.
+The 'itemRenderDirection' property is an enum which decides the order in which your items will be rendered in subsequent rows. For eg. Left-Right | Right-Left | Shortest column filling up first.
 
 ``` objc
 @property (nonatomic, assign) NSInteger columnCount;
@@ -48,6 +49,7 @@ Below lists the properties for you to customize the layout. Although they have d
 @property (nonatomic, assign) CGFloat headerHeight;
 @property (nonatomic, assign) CGFloat footerHeight;
 @property (nonatomic, assign) UIEdgeInsets sectionInset;
+@property (nonatomic, assign) ItemRenderDirection itemRenderDirection;
 ```
 
 #### Step 2


### PR DESCRIPTION
Adding a configuration option to determine the order of rendering the items.

Options include Left-to-Right | Right-to-Left | Shortest column first (existing default).

A new enum has been defined for ItemRenderDirection with 3 values:
kItemRenderDirectionShortestFirst, kItemRenderDirectionLTR, kItemRenderDirectionRTL
