### PR TITLE
Fix iPad demo.

### DIFF
--- a/Demo/Demo/Demo-Info.plist
+++ b/Demo/Demo/Demo-Info.plist
@@ -27,7 +27,7 @@
 	<key>UIMainStoryboardFile</key>
 	<string>MainStoryboard_iPhone</string>
 	<key>UIMainStoryboardFile~ipad</key>
-	<string>MainStoryboard_iPad</string>
+	<string>MainStoryboard_iPhone</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
Could not find a storyboard named 'MainStoryboard_iPad'.
