### PR TITLE
Long cell disappearing fix

### DIFF
--- a/CHTCollectionViewWaterfallLayout.m
+++ b/CHTCollectionViewWaterfallLayout.m
@@ -354,11 +354,16 @@ const NSInteger unionSize = 20;
   idx = 0;
   NSInteger itemCounts = [self.allItemAttributes count];
   while (idx < itemCounts) {
-    CGRect rect1 = ((UICollectionViewLayoutAttributes *)self.allItemAttributes[idx]).frame;
-    idx = MIN(idx + unionSize, itemCounts) - 1;
-    CGRect rect2 = ((UICollectionViewLayoutAttributes *)self.allItemAttributes[idx]).frame;
-    [self.unionRects addObject:[NSValue valueWithCGRect:CGRectUnion(rect1, rect2)]];
-    idx++;
+    CGRect unionRect = ((UICollectionViewLayoutAttributes *)self.allItemAttributes[idx]).frame;
+    NSInteger rectEndIndex = MIN(idx + unionSize, itemCounts);
+      
+    for (NSInteger i = idx + 1; i < rectEndIndex; i++) {
+      unionRect = CGRectUnion(unionRect, ((UICollectionViewLayoutAttributes *)self.allItemAttributes[i]).frame);
+    }
+      
+    idx = rectEndIndex;
+      
+    [self.unionRects addObject:[NSValue valueWithCGRect:unionRect]];
   }
 }
 


### PR DESCRIPTION
In the process of creating the union rects, the prior code has the assumption that the last element within a given set of elements is the has the lowest position. However, this assumption is not always correct. In the case where cells have varying heights, it is possible for another cell to have the lowest point. This results in the union rect not containing all the cells correctly. See picture:
![img_0007](https://cloud.githubusercontent.com/assets/8495063/5053407/dab8b07a-6bfe-11e4-96bb-8aab46c468ee.JPG)

The impact of this is that when scrolling past the bounds of the unionrect, the tall cell will disappear. Since the tall cell could be any one of the cells, from the first cell to the last one, the fix was to take the union of each cell in the group. It was tested and found that the performance degradation is approximately 5%.
