### PR TITLE
changed CGrectGetMaxX to CGRectGetMaxY, to get actual header height, not...

### DIFF
--- a/CHTCollectionViewWaterfallLayout.swift
+++ b/CHTCollectionViewWaterfallLayout.swift
@@ -186,7 +186,7 @@ class CHTCollectionViewWaterfallLayout : UICollectionViewLayout{
                 self.headersAttributes.setObject(attributes, forKey: (section))
                 self.allItemAttributes.addObject(attributes)
             
-                top = CGRectGetMaxX(attributes.frame)
+                top = CGRectGetMaxY(attributes.frame)
             }
             top += sectionInset.top
             for var idx = 0; idx < self.columnCount; idx++ {


### PR DESCRIPTION
there was a bug when using the .swift version - the layout cells would appear far down from the header if the header cell height was set to greater than zero.  i determined it was because CGRectGetMaxX was being used instead of the 'Y' counterpart.  The Obj-C version uses CGRectGetMaxY as well.  This solved the issue on my development app.

Thanks for creating a .swift version!   :)
