### PR TITLE
Fix for issue when layout is rotated

### DIFF
--- a/CHTCollectionViewWaterfallLayout.m
+++ b/CHTCollectionViewWaterfallLayout.m
@@ -117,7 +117,7 @@ static CGFloat CHTFloorCGFloat(CGFloat value) {
   } else {
     sectionInset = self.sectionInset;
   }
-  CGFloat width = self.collectionView.frame.size.width - sectionInset.left - sectionInset.right;
+  CGFloat width = self.collectionView.bounds.size.width - sectionInset.left - sectionInset.right;
   NSInteger columnCount = [self columnCountForSection:section];
   return CHTFloorCGFloat((width - (columnCount - 1) * self.minimumColumnSpacing) / columnCount);
 }
@@ -248,7 +248,7 @@ static CGFloat CHTFloorCGFloat(CGFloat value) {
       sectionInset = self.sectionInset;
     }
 
-    CGFloat width = self.collectionView.frame.size.width - sectionInset.left - sectionInset.right;
+    CGFloat width = self.collectionView.bounds.size.width - sectionInset.left - sectionInset.right;
     NSInteger columnCount = [self columnCountForSection:section];
     CGFloat itemWidth = CHTFloorCGFloat((width - (columnCount - 1) * self.minimumColumnSpacing) / columnCount);
 
@@ -275,7 +275,7 @@ static CGFloat CHTFloorCGFloat(CGFloat value) {
       attributes = [UICollectionViewLayoutAttributes layoutAttributesForSupplementaryViewOfKind:CHTCollectionElementKindSectionHeader withIndexPath:[NSIndexPath indexPathForItem:0 inSection:section]];
       attributes.frame = CGRectMake(headerInset.left,
                                     top,
-                                    self.collectionView.frame.size.width - (headerInset.left + headerInset.right),
+                                    self.collectionView.bounds.size.width - (headerInset.left + headerInset.right),
                                     headerHeight);
 
       self.headersAttribute[@(section)] = attributes;
@@ -342,7 +342,7 @@ static CGFloat CHTFloorCGFloat(CGFloat value) {
       attributes = [UICollectionViewLayoutAttributes layoutAttributesForSupplementaryViewOfKind:CHTCollectionElementKindSectionFooter withIndexPath:[NSIndexPath indexPathForItem:0 inSection:section]];
       attributes.frame = CGRectMake(footerInset.left,
                                     top,
-                                    self.collectionView.frame.size.width - (footerInset.left + footerInset.right),
+                                    self.collectionView.bounds.size.width - (footerInset.left + footerInset.right),
                                     footerHeight);
 
       self.footersAttribute[@(section)] = attributes;

--- a/CHTCollectionViewWaterfallLayout.swift
+++ b/CHTCollectionViewWaterfallLayout.swift
@@ -119,7 +119,7 @@ class CHTCollectionViewWaterfallLayout : UICollectionViewLayout{
         }else{
             insets = self.sectionInset
         }
-        let width:CGFloat = self.collectionView!.frame.size.width - sectionInset.left-sectionInset.right
+        let width:CGFloat = self.collectionView!.bounds.size.width - sectionInset.left-sectionInset.right
         let spaceColumCount:CGFloat = CGFloat(self.columnCount-1)
         return floor((width - (spaceColumCount*self.minimumColumnSpacing)) / CGFloat(self.columnCount))
     }
@@ -166,7 +166,7 @@ class CHTCollectionViewWaterfallLayout : UICollectionViewLayout{
                 sectionInsets = self.sectionInset
             }
             
-            let width = self.collectionView!.frame.size.width - sectionInset.left - sectionInset.right
+            let width = self.collectionView!.bounds.size.width - sectionInset.left - sectionInset.right
             let spaceColumCount = CGFloat(self.columnCount-1)
             let itemWidth = floor((width - (spaceColumCount*self.minimumColumnSpacing)) / CGFloat(self.columnCount))
             
@@ -182,7 +182,7 @@ class CHTCollectionViewWaterfallLayout : UICollectionViewLayout{
             
             if heightHeader > 0 {
                 attributes = UICollectionViewLayoutAttributes(forSupplementaryViewOfKind: CHTCollectionElementKindSectionHeader, withIndexPath: NSIndexPath(forRow: 0, inSection: section))
-                attributes.frame = CGRectMake(0, top, self.collectionView!.frame.size.width, heightHeader)
+                attributes.frame = CGRectMake(0, top, self.collectionView!.bounds.size.width, heightHeader)
                 self.headersAttributes.setObject(attributes, forKey: (section))
                 self.allItemAttributes.addObject(attributes)
             
@@ -235,7 +235,7 @@ class CHTCollectionViewWaterfallLayout : UICollectionViewLayout{
             
             if footerHeight > 0 {
                 attributes = UICollectionViewLayoutAttributes(forSupplementaryViewOfKind: CHTCollectionElementKindSectionFooter, withIndexPath: NSIndexPath(forItem: 0, inSection: section))
-                attributes.frame = CGRectMake(0, top, self.collectionView!.frame.size.width, footerHeight)
+                attributes.frame = CGRectMake(0, top, self.collectionView!.bounds.size.width, footerHeight)
                 self.footersAttributes.setObject(attributes, forKey: section)
                 self.allItemAttributes.addObject(attributes)
                 top = CGRectGetMaxY(attributes.frame)


### PR DESCRIPTION
@chiahsien We were having issues with the frame vs. bounds values when we rotated the view to support horizontal scrolling (admittedly, I've been meaning to look into adding this support, but we were in a time crunch :) ), and iOS sometimes has a discrepancy between frame and bounds values when adjusting the transform of a view. Let me know if you have any concerns here!