### PR TITLE
Fixed index out of bounds exception 

### DIFF
--- a/CHTCollectionViewWaterfallLayout.m
+++ b/CHTCollectionViewWaterfallLayout.m
@@ -332,8 +332,12 @@ static CGFloat CHTFloorCGFloat(CGFloat value) {
      */
     CGFloat footerHeight;
     NSUInteger columnIndex = [self longestColumnIndexInSection:section];
-    top = [self.columnHeights[section][columnIndex] floatValue] - minimumInteritemSpacing + sectionInset.bottom;
-
+    if (((NSArray *)self.columnHeights[section]).count > 0) {
+      top = [self.columnHeights[section][columnIndex] floatValue] - minimumInteritemSpacing + sectionInset.bottom;
+    } else {
+		  top = 0;
+	  }
+	  
     if ([self.delegate respondsToSelector:@selector(collectionView:layout:heightForFooterInSection:)]) {
       footerHeight = [self.delegate collectionView:self.collectionView layout:self heightForFooterInSection:section];
     } else {


### PR DESCRIPTION
If self.columnHeights[section] had no objects (columns) and index out of bounds exception was raised.
