### PR TITLE
Add Carthage compatibility badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 CHTCollectionViewWaterfallLayout
 ===============================
 
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Version](https://cocoapod-badges.herokuapp.com/v/CHTCollectionViewWaterfallLayout/badge.png)](http://cocoadocs.org/docsets/CHTCollectionViewWaterfallLayout)
 [![Platform](https://cocoapod-badges.herokuapp.com/p/CHTCollectionViewWaterfallLayout/badge.png)](http://cocoadocs.org/docsets/CHTCollectionViewWaterfallLayout)
 [![Build Status](https://travis-ci.org/chiahsien/CHTCollectionViewWaterfallLayout.svg?branch=develop)](https://travis-ci.org/chiahsien/CHTCollectionViewWaterfallLayout)


### PR DESCRIPTION
Also there hasn't been a GitHub release since #126 was merged, so even though Carthage grabs from the "default branch" (`develop`) it won't build the framework because it's using the commit of the last release. If you could make a new release that'd be 👌 

Until then as a workaround users can add this to their Cartfile:
```
github "chiahsien/CHTCollectionViewWaterfallLayout" "develop"
```