### PR TITLE
Fixes, improvements, Xcode 8 and Swift 2.3 

### DIFF
--- a/CHTCollectionViewWaterfallLayout.swift
+++ b/CHTCollectionViewWaterfallLayout.swift
@@ -40,38 +40,38 @@ public let CHTCollectionElementKindSectionHeader = "CHTCollectionElementKindSect
 public let CHTCollectionElementKindSectionFooter = "CHTCollectionElementKindSectionFooter"
 
 public class CHTCollectionViewWaterfallLayout : UICollectionViewLayout{
-    public var columnCount : NSInteger{
+    public var columnCount : NSInteger = 2 {
     didSet{
         invalidateLayout()
     }}
     
-    public var minimumColumnSpacing : CGFloat{
+    public var minimumColumnSpacing : CGFloat = 10 {
     didSet{
         invalidateLayout()
     }}
     
-    public var minimumInteritemSpacing : CGFloat{
+    public var minimumInteritemSpacing : CGFloat = 10 {
     didSet{
         invalidateLayout()
     }}
     
-    public var headerHeight : CGFloat{
+    public var headerHeight : CGFloat = 0 {
     didSet{
         invalidateLayout()
     }}
 
-    public var footerHeight : CGFloat{
+    public var footerHeight : CGFloat = 0 {
     didSet{
         invalidateLayout()
     }}
 
-    public var sectionInset : UIEdgeInsets{
+    public var sectionInset = UIEdgeInsets() {
     didSet{
         invalidateLayout()
     }}
     
     
-    public var itemRenderDirection : CHTCollectionViewWaterfallLayoutItemRenderDirection{
+    public var itemRenderDirection : CHTCollectionViewWaterfallLayoutItemRenderDirection = .CHTCollectionViewWaterfallLayoutItemRenderDirectionShortestFirst {
     didSet{
         invalidateLayout()
     }}
@@ -82,37 +82,21 @@ public class CHTCollectionViewWaterfallLayout : UICollectionViewLayout{
     }
     }
     
-    private var columnHeights : NSMutableArray
-    private var sectionItemAttributes : NSMutableArray
-    private var allItemAttributes : NSMutableArray
-    private var headersAttributes : NSMutableDictionary
-    private var footersAttributes : NSMutableDictionary
-    private  var unionRects : NSMutableArray
+    private var columnHeights = NSMutableArray()
+    private var sectionItemAttributes = NSMutableArray()
+    private var allItemAttributes = NSMutableArray()
+    private var headersAttributes = NSMutableDictionary()
+    private var footersAttributes = NSMutableDictionary()
+    private  var unionRects = NSMutableArray()
     private let unionSize = 20
     
     override public init(){
-        self.headerHeight = 0.0
-        self.footerHeight = 0.0
-        self.columnCount = 2
-        self.minimumInteritemSpacing = 10
-        self.minimumColumnSpacing = 10
-        self.sectionInset = UIEdgeInsetsZero
-        self.itemRenderDirection =
-        CHTCollectionViewWaterfallLayoutItemRenderDirection.CHTCollectionViewWaterfallLayoutItemRenderDirectionShortestFirst
-
-        headersAttributes = NSMutableDictionary()
-        footersAttributes = NSMutableDictionary()
-        unionRects = NSMutableArray()
-        columnHeights = NSMutableArray()
-        allItemAttributes = NSMutableArray()
-        sectionItemAttributes = NSMutableArray()
-        
         super.init()
     }
     
     required public init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
+      super.init(coder: aDecoder)
+  }
   
     func columnCountForSection (section : NSInteger) -> NSInteger {
         if let columnCount = self.delegate?.collectionView?(self.collectionView!, layout: self, columnCountForSection: section){

--- a/CHTCollectionViewWaterfallLayout.swift
+++ b/CHTCollectionViewWaterfallLayout.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Nicholas Tau. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 @objc public protocol CHTCollectionViewDelegateWaterfallLayout: UICollectionViewDelegate{
@@ -30,14 +29,14 @@ import UIKit
         columnCountForSection section: NSInteger) -> NSInteger
 }
 
-public enum CHTCollectionViewWaterfallLayoutItemRenderDirection : NSInteger{
-    case CHTCollectionViewWaterfallLayoutItemRenderDirectionShortestFirst
-    case CHTCollectionViewWaterfallLayoutItemRenderDirectionLeftToRight
-    case CHTCollectionViewWaterfallLayoutItemRenderDirectionRightToLeft
+public enum CHTCollectionViewWaterfallLayoutItemRenderDirection : NSInteger {
+    case shortestFirst, leftToRight, rightToLeft
 }
 
-public let CHTCollectionElementKindSectionHeader = "CHTCollectionElementKindSectionHeader"
-public let CHTCollectionElementKindSectionFooter = "CHTCollectionElementKindSectionFooter"
+public enum CHTCollectionElementKind {
+  public static var sectionHeader: String { return "CHTCollectionElementKindSectionHeader" }
+  public static var sectionFooter: String { return "CHTCollectionElementKindSectionFooter" }
+}
 
 public class CHTCollectionViewWaterfallLayout : UICollectionViewLayout{
     public var columnCount : NSInteger = 2 {
@@ -71,7 +70,7 @@ public class CHTCollectionViewWaterfallLayout : UICollectionViewLayout{
     }}
     
     
-    public var itemRenderDirection : CHTCollectionViewWaterfallLayoutItemRenderDirection = .CHTCollectionViewWaterfallLayoutItemRenderDirectionShortestFirst {
+    public var itemRenderDirection = CHTCollectionViewWaterfallLayoutItemRenderDirection.shortestFirst {
     didSet{
         invalidateLayout()
     }}
@@ -151,8 +150,8 @@ public class CHTCollectionViewWaterfallLayout : UICollectionViewLayout{
             * 1. Get section-specific metrics (minimumInteritemSpacing, sectionInset)
             */
             var minimumInteritemSpacing : CGFloat
-            if let miniumSpaceing = self.delegate?.collectionView?(self.collectionView!, layout: self, minimumInteritemSpacingForSectionAtIndex: section){
-                minimumInteritemSpacing = miniumSpaceing
+            if let minimumSpacing = self.delegate?.collectionView?(self.collectionView!, layout: self, minimumInteritemSpacingForSectionAtIndex: section){
+                minimumInteritemSpacing = minimumSpacing
             }else{
                 minimumInteritemSpacing = self.minimumColumnSpacing
             }
@@ -180,7 +179,7 @@ public class CHTCollectionViewWaterfallLayout : UICollectionViewLayout{
             }
             
             if heightHeader > 0 {
-                attributes = UICollectionViewLayoutAttributes(forSupplementaryViewOfKind: CHTCollectionElementKindSectionHeader, withIndexPath: NSIndexPath(forRow: 0, inSection: section))
+                attributes = UICollectionViewLayoutAttributes(forSupplementaryViewOfKind: CHTCollectionElementKind.sectionHeader, withIndexPath: NSIndexPath(forRow: 0, inSection: section))
                 attributes.frame = CGRectMake(0, top, self.collectionView!.bounds.size.width, heightHeader)
                 self.headersAttributes.setObject(attributes, forKey: (section))
                 self.allItemAttributes.addObject(attributes)
@@ -238,7 +237,7 @@ public class CHTCollectionViewWaterfallLayout : UICollectionViewLayout{
             }
             
             if footerHeight > 0 {
-                attributes = UICollectionViewLayoutAttributes(forSupplementaryViewOfKind: CHTCollectionElementKindSectionFooter, withIndexPath: NSIndexPath(forItem: 0, inSection: section))
+                attributes = UICollectionViewLayoutAttributes(forSupplementaryViewOfKind: CHTCollectionElementKind.sectionFooter, withIndexPath: NSIndexPath(forItem: 0, inSection: section))
                 attributes.frame = CGRectMake(0, top, self.collectionView!.bounds.size.width, footerHeight)
                 self.footersAttributes.setObject(attributes, forKey: section)
                 self.allItemAttributes.addObject(attributes)
@@ -289,9 +288,9 @@ public class CHTCollectionViewWaterfallLayout : UICollectionViewLayout{
     
     override public func layoutAttributesForSupplementaryViewOfKind(elementKind: String, atIndexPath indexPath: NSIndexPath) -> UICollectionViewLayoutAttributes{
         var attribute = UICollectionViewLayoutAttributes()
-        if elementKind == CHTCollectionElementKindSectionHeader{
+        if elementKind == CHTCollectionElementKind.sectionHeader {
             attribute = self.headersAttributes.objectForKey(indexPath.section) as! UICollectionViewLayoutAttributes
-        }else if elementKind == CHTCollectionElementKindSectionFooter{
+        }else if elementKind == CHTCollectionElementKind.sectionFooter {
             attribute = self.footersAttributes.objectForKey(indexPath.section) as! UICollectionViewLayoutAttributes
         }
         return attribute
@@ -384,11 +383,11 @@ public class CHTCollectionViewWaterfallLayout : UICollectionViewLayout{
         var index = 0
         let columnCount = self.columnCountForSection(section)
         switch (self.itemRenderDirection){
-        case .CHTCollectionViewWaterfallLayoutItemRenderDirectionShortestFirst :
+        case .shortestFirst :
             index = self.shortestColumnIndexInSection(section)
-        case .CHTCollectionViewWaterfallLayoutItemRenderDirectionLeftToRight :
+        case .leftToRight :
             index = (item%columnCount)
-        case .CHTCollectionViewWaterfallLayoutItemRenderDirectionRightToLeft:
+        case .rightToLeft:
             index = (columnCount - 1) - (item % columnCount);
         }
         return index

--- a/Demo/Swift/CHTWaterfallSwiftDemo.xcodeproj/project.pbxproj
+++ b/Demo/Swift/CHTWaterfallSwiftDemo.xcodeproj/project.pbxproj
@@ -178,14 +178,16 @@
 			attributes = {
 				LastSwiftMigration = 0730;
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0730;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Sophie Fader";
 				TargetAttributes = {
 					62C26FD81ABE01840027F8D4 = {
 						CreatedOnToolsVersion = 6.1.1;
+						LastSwiftMigration = 0800;
 					};
 					62C26FED1ABE01850027F8D4 = {
 						CreatedOnToolsVersion = 6.1.1;
+						LastSwiftMigration = 0800;
 						TestTargetID = 62C26FD81ABE01840027F8D4;
 					};
 				};
@@ -286,8 +288,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -296,6 +300,7 @@
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -330,8 +335,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -339,6 +346,7 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -348,6 +356,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -358,12 +367,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = CHTWaterfallSwiftDemo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sophiefader.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -372,11 +383,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = CHTWaterfallSwiftDemo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sophiefader.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -396,6 +409,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sophiefader.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CHTWaterfallSwiftDemo.app/CHTWaterfallSwiftDemo";
 			};
 			name = Debug;
@@ -412,6 +426,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sophiefader.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CHTWaterfallSwiftDemo.app/CHTWaterfallSwiftDemo";
 			};
 			name = Release;

--- a/Demo/Swift/CHTWaterfallSwiftDemo/ImageUICollectionViewCell.xib
+++ b/Demo/Swift/CHTWaterfallSwiftDemo/ImageUICollectionViewCell.xib
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="cell" id="gTV-IL-0wX" customClass="ImageUICollectionViewCell" customModule="CHTWaterfallSwift" customModuleProvider="target">
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="cell" id="gTV-IL-0wX" customClass="ImageUICollectionViewCell" customModule="CHTWaterfallSwiftDemo" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="236" height="231"/>
             <autoresizingMask key="autoresizingMask"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                 <rect key="frame" x="0.0" y="0.0" width="236" height="231"/>
+                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
-                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="2bW-1Q-SeU">
-                        <rect key="frame" x="0.0" y="0.0" width="236" height="231"/>
-                    </imageView>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="2bW-1Q-SeU"/>
                 </subviews>
-                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
             </view>
             <constraints>
                 <constraint firstItem="2bW-1Q-SeU" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="5h1-1c-duS"/>


### PR DESCRIPTION
I've updated the Swift demo project to Xcode 8 configuration.
Also, I've fixed a crash when instantiating the layout from storyboard ("initWithCoder:"), to do this I had to implement the Swift default initialization for layout properties.

I've shortened the renderDirection enum cases for better readability.
I've encapsulated CHTCollectionElementKind's into an enum to avoid possible namespace conflicts (and avoid using "global" variables).