### PR TITLE
make the header && footer public

### DIFF
--- a/CHTCollectionViewWaterfallLayout.swift
+++ b/CHTCollectionViewWaterfallLayout.swift
@@ -56,9 +56,9 @@ enum CHTCollectionViewWaterfallLayoutItemRenderDirection : NSInteger{
     case chtCollectionViewWaterfallLayoutItemRenderDirectionRightToLeft
 }
 
+public  let CHTCollectionElementKindSectionHeader = "CHTCollectionElementKindSectionHeader"
+public  let CHTCollectionElementKindSectionFooter = "CHTCollectionElementKindSectionFooter"
 class CHTCollectionViewWaterfallLayout : UICollectionViewLayout{
-    let CHTCollectionElementKindSectionHeader = "CHTCollectionElementKindSectionHeader"
-    let CHTCollectionElementKindSectionFooter = "CHTCollectionElementKindSectionFooter"
     
     var columnCount : NSInteger{
         didSet{


### PR DESCRIPTION
change CHTCollectionElementKindSectionHeader &&
CHTCollectionElementKindSectionFooter
to public so you can use in
public func collectionView(_ collectionView: UICollectionView,
viewForSupplementaryElementOfKind kind: String, at indexPath:
IndexPath) -> UICollectionReusableView
