### PR TITLE
Add a flag to keep the original item size

### DIFF
--- a/CHTCollectionViewWaterfallLayout.h
+++ b/CHTCollectionViewWaterfallLayout.h
@@ -307,6 +307,16 @@ extern NSString *const CHTCollectionElementKindSectionFooter;
 @property (nonatomic, assign) CHTCollectionViewWaterfallLayoutItemRenderDirection itemRenderDirection;
 
 /**
+ *  @brief Controls whether the original height of the items should be kept.
+ *  @discussion
+ *    When set to YES, the original height returned by collectionView:layout:sizeForItemAtIndexPath: will be used for each cell.
+ *
+ *    Default: NO
+ */
+@property (nonatomic, assign) BOOL keepOriginalItemHeight;
+
+
+/**
  *  @brief The minimum height of the collection view's content.
  *  @discussion
  *    The minimum height of the collection view's content. This could be used to allow hidden headers with no content.

--- a/CHTCollectionViewWaterfallLayout.m
+++ b/CHTCollectionViewWaterfallLayout.m
@@ -322,7 +322,7 @@ static CGFloat CHTFloorCGFloat(CGFloat value) {
       CGSize itemSize = [self.delegate collectionView:self.collectionView layout:self sizeForItemAtIndexPath:indexPath];
       CGFloat itemHeight = 0;
       if (_keepOriginalItemHeight) {
-        itemHeight = itemSize.height
+        itemHeight = itemSize.height;
       }
       else if (itemSize.height > 0 && itemSize.width > 0) {
         itemHeight = CHTFloorCGFloat(itemSize.height * itemWidth / itemSize.width);

--- a/CHTCollectionViewWaterfallLayout.m
+++ b/CHTCollectionViewWaterfallLayout.m
@@ -102,6 +102,13 @@ static CGFloat CHTFloorCGFloat(CGFloat value) {
   }
 }
 
+- (void)setKeepOriginalItemHeight:(BOOL)keepOriginalItemHeight {
+    if (_keepOriginalItemHeight != keepOriginalItemHeight) {
+        _keepOriginalItemHeight = keepOriginalItemHeight;
+        [self invalidateLayout];
+    }
+}
+
 - (NSInteger)columnCountForSection:(NSInteger)section {
   if ([self.delegate respondsToSelector:@selector(collectionView:layout:columnCountForSection:)]) {
     return [self.delegate collectionView:self.collectionView layout:self columnCountForSection:section];
@@ -314,7 +321,10 @@ static CGFloat CHTFloorCGFloat(CGFloat value) {
       CGFloat yOffset = [self.columnHeights[section][columnIndex] floatValue];
       CGSize itemSize = [self.delegate collectionView:self.collectionView layout:self sizeForItemAtIndexPath:indexPath];
       CGFloat itemHeight = 0;
-      if (itemSize.height > 0 && itemSize.width > 0) {
+      if (_keepOriginalItemHeight) {
+        itemHeight = itemSize.height
+      }
+      else if (itemSize.height > 0 && itemSize.width > 0) {
         itemHeight = CHTFloorCGFloat(itemSize.height * itemWidth / itemSize.width);
       }
 

--- a/CHTCollectionViewWaterfallLayout.swift
+++ b/CHTCollectionViewWaterfallLayout.swift
@@ -95,6 +95,12 @@ class CHTCollectionViewWaterfallLayout: UICollectionViewLayout {
             invalidateLayout()
         }
     }
+    
+    var keepOriginalItemHeight = false {
+        didSet {
+            invalidateLayout()
+        }
+    }
 
 
     //    private property and method above.
@@ -245,7 +251,9 @@ class CHTCollectionViewWaterfallLayout: UICollectionViewLayout {
                 let yOffset = ((self.columnHeights[section] as AnyObject).object (at: columnIndex) as AnyObject).doubleValue
                 let itemSize = self.delegate?.collectionView(self.collectionView!, layout: self, sizeForItemAtIndexPath: indexPath)
                 var itemHeight: CGFloat = 0.0
-                if itemSize?.height > 0 && itemSize?.width > 0 {
+                if keepOriginalItemHeight {
+                    itemHeight = itemSize!.height
+                } else if itemSize?.height > 0 && itemSize?.width > 0 {
                     itemHeight = floor(itemSize!.height * itemWidth / itemSize!.width)
                 }
 

--- a/Demo/Swift/CHTWaterfallSwiftDemo.xcodeproj/project.pbxproj
+++ b/Demo/Swift/CHTWaterfallSwiftDemo.xcodeproj/project.pbxproj
@@ -183,9 +183,11 @@
 				TargetAttributes = {
 					62C26FD81ABE01840027F8D4 = {
 						CreatedOnToolsVersion = 6.1.1;
+						LastSwiftMigration = 0820;
 					};
 					62C26FED1ABE01850027F8D4 = {
 						CreatedOnToolsVersion = 6.1.1;
+						LastSwiftMigration = 0820;
 						TestTargetID = 62C26FD81ABE01840027F8D4;
 					};
 				};
@@ -364,6 +366,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -377,6 +380,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sophiefader.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -396,6 +400,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sophiefader.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CHTWaterfallSwiftDemo.app/CHTWaterfallSwiftDemo";
 			};
 			name = Debug;
@@ -412,6 +417,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sophiefader.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CHTWaterfallSwiftDemo.app/CHTWaterfallSwiftDemo";
 			};
 			name = Release;

--- a/Demo/Swift/CHTWaterfallSwiftDemo/AppDelegate.swift
+++ b/Demo/Swift/CHTWaterfallSwiftDemo/AppDelegate.swift
@@ -12,32 +12,30 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
-
-
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
-        // Override point for customization after application launch.
+    
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         return true
     }
-
-    func applicationWillResignActive(application: UIApplication) {
+    
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 

--- a/Demo/Swift/CHTWaterfallSwiftDemo/ViewController.swift
+++ b/Demo/Swift/CHTWaterfallSwiftDemo/ViewController.swift
@@ -48,7 +48,7 @@ class ViewController: UIViewController, UICollectionViewDelegate, UICollectionVi
         layout.minimumInteritemSpacing = 1.0
         
         // Collection view attributes
-        self.collectionView.autoresizingMask = [UIViewAutoresizing.FlexibleHeight, UIViewAutoresizing.FlexibleWidth]
+        self.collectionView.autoresizingMask = [UIViewAutoresizing.flexibleHeight, UIViewAutoresizing.flexibleWidth]
         self.collectionView.alwaysBounceVertical = true
         
         // Add the waterfall layout to your collection view
@@ -60,7 +60,7 @@ class ViewController: UIViewController, UICollectionViewDelegate, UICollectionVi
         
         // attach the UI nib file for the ImageUICollectionViewCell to the collectionview 
         let viewNib = UINib(nibName: "ImageUICollectionViewCell", bundle: nil)
-        collectionView.registerNib(viewNib, forCellWithReuseIdentifier: "cell")
+        collectionView.register(viewNib, forCellWithReuseIdentifier: "cell")
     }
     
     
@@ -69,16 +69,16 @@ class ViewController: UIViewController, UICollectionViewDelegate, UICollectionVi
     //MARK: - CollectionView Delegate Methods
     
      //** Number of Cells in the CollectionView */
-    func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return model.images.count
     }
     
     
     //** Create a basic CollectionView Cell */
-    func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell {
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         
         // Create the cell and return the cell
-        let cell = collectionView.dequeueReusableCellWithReuseIdentifier("cell", forIndexPath: indexPath) as! ImageUICollectionViewCell
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "cell", for: indexPath as IndexPath) as! ImageUICollectionViewCell
         
         // Add image to cell
         cell.image.image = model.images[indexPath.row]
@@ -89,7 +89,7 @@ class ViewController: UIViewController, UICollectionViewDelegate, UICollectionVi
     //MARK: - CollectionView Waterfall Layout Delegate Methods (Required)
     
     //** Size for the cells in the Waterfall Layout */
-    func collectionView(collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAtIndexPath indexPath: NSIndexPath) -> CGSize {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAtIndexPath indexPath: IndexPath) -> CGSize {
         // create a cell size from the image size, and return the size
         let imageSize = model.images[indexPath.row].size
         

--- a/Demo/Swift/CHTWaterfallSwiftDemoTests/CHTWaterfallSwiftDemoTests.swift
+++ b/Demo/Swift/CHTWaterfallSwiftDemoTests/CHTWaterfallSwiftDemoTests.swift
@@ -28,7 +28,7 @@ class CHTWaterfallSwiftDemoTests: XCTestCase {
     
     func testPerformanceExample() {
         // This is an example of a performance test case.
-        self.measureBlock() {
+        self.measure() {
             // Put the code you want to measure the time of here.
         }
     }

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The `itemRenderDirection` property is an enum which decides the order in which y
 @property (nonatomic, assign) CGFloat footerHeight;
 @property (nonatomic, assign) UIEdgeInsets sectionInset;
 @property (nonatomic, assign) ItemRenderDirection itemRenderDirection;
+@property (nonatomic, assign) BOOL keepOriginalItemHeight;
 ```
 
 #### Step 2


### PR DESCRIPTION
In our project we needed to keep the original item height returned by the collectionView:layout:itemSize delegate method instead of recalculating it based on the calculated itemWidth and the ratio of the itemSize.

Added a keepOriginalItemHeight flag to control this behaviour with a default NO/false value and converted the Swift implementation to Swift 3.0.