### PR TITLE
Prevent multiple layout attrs for the same object

### DIFF
--- a/CHTCollectionViewWaterfallLayout.m
+++ b/CHTCollectionViewWaterfallLayout.m
@@ -423,7 +423,7 @@ static CGFloat CHTFloorCGFloat(CGFloat value) {
 - (NSArray *)layoutAttributesForElementsInRect:(CGRect)rect {
   NSInteger i;
   NSInteger begin = 0, end = self.unionRects.count;
-  NSMutableArray *attrs = [NSMutableArray array];
+  NSMutableDictionary *attrDict = [NSMutableDictionary dictionary];
 
   for (i = 0; i < self.unionRects.count; i++) {
     if (CGRectIntersectsRect(rect, [self.unionRects[i] CGRectValue])) {
@@ -440,11 +440,11 @@ static CGFloat CHTFloorCGFloat(CGFloat value) {
   for (i = begin; i < end; i++) {
     UICollectionViewLayoutAttributes *attr = self.allItemAttributes[i];
     if (CGRectIntersectsRect(rect, attr.frame)) {
-      [attrs addObject:attr];
+      attrDict[attr.indexPath] = attr;
     }
   }
 
-  return [NSArray arrayWithArray:attrs];
+  return [NSArray arrayWithArray:attrDict.allValues];
 }
 
 - (BOOL)shouldInvalidateLayoutForBoundsChange:(CGRect)newBounds {

--- a/CHTCollectionViewWaterfallLayout.m
+++ b/CHTCollectionViewWaterfallLayout.m
@@ -423,7 +423,9 @@ static CGFloat CHTFloorCGFloat(CGFloat value) {
 - (NSArray *)layoutAttributesForElementsInRect:(CGRect)rect {
   NSInteger i;
   NSInteger begin = 0, end = self.unionRects.count;
-  NSMutableDictionary *attrDict = [NSMutableDictionary dictionary];
+  NSMutableDictionary *cellAttrDict = [NSMutableDictionary dictionary];
+  NSMutableDictionary *supplAttrDict = [NSMutableDictionary dictionary];
+  NSMutableDictionary *decorAttrDict = [NSMutableDictionary dictionary];
 
   for (i = 0; i < self.unionRects.count; i++) {
     if (CGRectIntersectsRect(rect, [self.unionRects[i] CGRectValue])) {
@@ -440,11 +442,23 @@ static CGFloat CHTFloorCGFloat(CGFloat value) {
   for (i = begin; i < end; i++) {
     UICollectionViewLayoutAttributes *attr = self.allItemAttributes[i];
     if (CGRectIntersectsRect(rect, attr.frame)) {
-      attrDict[attr.indexPath] = attr;
+      switch (attr.representedElementCategory) {
+        case UICollectionElementCategorySupplementaryView:
+          supplAttrDict[attr.indexPath] = attr;
+          break;
+        case UICollectionElementCategoryDecorationView:
+          decorAttrDict[attr.indexPath] = attr;
+          break;
+        case UICollectionElementCategoryCell:
+          cellAttrDict[attr.indexPath] = attr;
+          break;
+      }
     }
   }
 
-  return [NSArray arrayWithArray:attrDict.allValues];
+  NSArray *result = [cellAttrDict.allValues arrayByAddingObjectsFromArray:supplAttrDict.allValues];
+  result = [result arrayByAddingObjectsFromArray:decorAttrDict.allValues];
+  return result;
 }
 
 - (BOOL)shouldInvalidateLayoutForBoundsChange:(CGRect)newBounds {


### PR DESCRIPTION
I've been getting a crash recently when trying to add headers to sections using your layout:

```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'layout attributes for supplementary item at index path (<NSIndexPath: 0xc000000000000116> {length = 2, path = 1 - 0}) changed from <UICollectionViewLayoutAttributes: 0x6100003e1f00> index path: (<NSIndexPath: 0xc000000000000116> {length = 2, path = 1 - 0}); element kind: (CHTCollectionElementKindSectionHeader); frame = (0 490; 768 20);  to <UICollectionViewLayoutAttributes: 0x6080003e1200> index path: (<NSIndexPath: 0xc000000000000116> {length = 2, path = 1 - 0}); element kind: (CHTCollectionElementKindSectionHeader); frame = (0 530; 768 20);  without invalidating the layout'
```

What I noticed is that multiple attributes were being generated for the same index path in `layoutAttributesForElementsInRect` so the `UICollectionView` got confused towards which one to use. This fix prevents that from happening.