### PR TITLE
update the demo show for release more easily

### DIFF
--- a/Demo/Objective-C/Demo/CHTCollectionViewWaterfallCell.m
+++ b/Demo/Objective-C/Demo/CHTCollectionViewWaterfallCell.m
@@ -15,7 +15,8 @@
   if (!_imageView) {
     _imageView = [[UIImageView alloc] initWithFrame:self.contentView.bounds];
     _imageView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-    _imageView.contentMode = UIViewContentModeScaleAspectFit;
+    _imageView.contentMode = UIViewContentModeScaleAspectFill;
+    [_imageView.layer setMasksToBounds:YES];
   }
   return _imageView;
 }

--- a/Demo/Objective-C/Demo/ViewController.m
+++ b/Demo/Objective-C/Demo/ViewController.m
@@ -55,7 +55,7 @@
 - (NSArray *)cellSizes {
   if (!_cellSizes) {
     _cellSizes = @[
-      [NSValue valueWithCGSize:CGSizeMake(400, 550)],
+      [NSValue valueWithCGSize:CGSizeMake(550, 550)],
       [NSValue valueWithCGSize:CGSizeMake(1000, 665)],
       [NSValue valueWithCGSize:CGSizeMake(1024, 689)],
       [NSValue valueWithCGSize:CGSizeMake(640, 427)]


### PR DESCRIPTION
the item size in collection equals ratio to the real size.But when I set the Size as {width:200,height:200},then run the demo,but the image also show the real size.So it confused me,I think also confused a lot of people who not read the source code.So I do a little change in the 'cell' file to show the item as the size we setted.
`   _imageView.contentMode = UIViewContentModeScaleAspectFill;`

`   [_imageView.layer setMasksToBounds:YES]; `
