### PR TITLE
Fix for minimumInteritemSpacing

### DIFF
--- a/CHTCollectionViewWaterfallLayout.swift
+++ b/CHTCollectionViewWaterfallLayout.swift
@@ -191,7 +191,7 @@ public class CHTCollectionViewWaterfallLayout: UICollectionViewLayout {
             if let miniumSpaceing = self.delegate?.collectionView?(self.collectionView!, layout: self, minimumInteritemSpacingForSectionAtIndex: section) {
                 minimumInteritemSpacing = miniumSpaceing
             } else {
-                minimumInteritemSpacing = self.minimumColumnSpacing
+                minimumInteritemSpacing = self.minimumInteritemSpacing
             }
 
             var sectionInsets: UIEdgeInsets


### PR DESCRIPTION
When trying to pick up the `minimumInteritemSpacing` from the delegate method ...
`@objc optional func collectionView (_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAtIndex section: Int) -> CGFloat`
... the code falls back to `minimumColumnSpacing` if the delegate method is not implemented. It should fall back to `minimumInteritemSpacing` instead.