### PR TITLE
(fix) ObjC: unified cell height logic with swift

### DIFF
--- a/Source/CHTCollectionViewWaterfallLayout.m
+++ b/Source/CHTCollectionViewWaterfallLayout.m
@@ -314,8 +314,11 @@ static CGFloat CHTFloorCGFloat(CGFloat value) {
       CGFloat yOffset = [self.columnHeights[section][columnIndex] floatValue];
       CGSize itemSize = [self.delegate collectionView:self.collectionView layout:self sizeForItemAtIndexPath:indexPath];
       CGFloat itemHeight = 0;
-      if (itemSize.height > 0 && itemSize.width > 0) {
-        itemHeight = CHTFloorCGFloat(itemSize.height * itemWidth / itemSize.width);
+      if (itemSize.height > 0){
+        itemHeight=itemSize.height;
+          if(itemSize.width > 0) {
+            itemHeight = CHTFloorCGFloat(itemSize.height * itemWidth / itemSize.width);
+          }
       }
 
       attributes = [UICollectionViewLayoutAttributes layoutAttributesForCellWithIndexPath:indexPath];


### PR DESCRIPTION
I realized that the SWIFT and ObjC packages differ in cell height logic.

The SWIFT version will set the height of the cell no matter what and will set the width when it's bigger than 0, otherwise it will set it to 50% of the screen width.

On ObjC on the other hand it will only set the height if the width is also bigger than 0.

The logic in Swift is [here](https://github.com/chiahsien/CHTCollectionViewWaterfallLayout/blob/88b81c251b96e3dd8ad6ea2cf647140ef1bc7c9b/Source/CHTCollectionViewWaterfallLayout.swift#L272) and the logic in ObjC is [here](https://github.com/chiahsien/CHTCollectionViewWaterfallLayout/blob/develop/Source/CHTCollectionViewWaterfallLayout.m#L317)

